### PR TITLE
Fix for Issue #21: added URL validation using RegEx

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -37,7 +37,7 @@
 
             } else if( URLregex.test($('#url').val()) == false) {
 
-                 $('#shortcode').html('<div class=\'alert alert-warning\'><strong>Invalid URL format</strong> <p> The url must be of form \"www.example.com"\ </br>or \"https://example.com\" </p> </div> ');
+                 $('#shortcode').html('<div class=\'alert alert-warning\'><strong>Invalid URL format</strong> <p> The URL must be of form </br>\"www.example.com"\ </br> \"https://example.com\" </br> \"mailto:foo@bar.com\" </p> </div> ');
                 $('#url').css('border-color', 'red');
 
             } else {

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -27,9 +27,19 @@
 <script>
     $(function () {
         $('#submit').click(function () {
-            if($('#url').val().length == 0) {
+
+            var URLregex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;  
+
+            if($('#url').val().length == 0) { 
+
                $('#shortcode').html('<div class=\'alert alert-danger\'><strong>URL field is empty</strong> </div>   ');
                 $('#url').css('border-color', 'red');
+
+            } else if( URLregex.test($('#url').val()) == false) {
+
+                 $('#shortcode').html('<div class=\'alert alert-warning\'><strong>Invalid URL format</strong> <p> The url must be of form \"www.example.com"\ </br>or \"https://example.com\" </p> </div> ');
+                $('#url').css('border-color', 'red');
+
             } else {
             
                 $.post('/api/v1/shorten', {


### PR DESCRIPTION
This regular expression validates URL with format 

- https://example.com
- www.example.com
- http://foo.bar
- mailto:example@mail.com
- ftp://193.120.32.13

It won't allow URL with patterns like 

- google.com (instead it requires "http(s):// or www." as prefix.)
- 192.168.1.1

It will  show user a warning message informing them of valid URL formats. 
![urlfix](https://cloud.githubusercontent.com/assets/9148945/25154097/cfedbffa-24ac-11e7-8e87-500881f622c3.PNG)
